### PR TITLE
fix: 献立カレンダー画面のヘッダーからプラスボタンを削除

### DIFF
--- a/components/screens/meal-plan-screen.tsx
+++ b/components/screens/meal-plan-screen.tsx
@@ -127,19 +127,6 @@ export function MealPlanScreen({ onBack }: MealPlanScreenProps) {
         title="献立カレンダー"
         showBack
         onBack={onBack}
-        rightElement={
-          <button
-            type="button"
-            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-primary hover:bg-accent"
-            aria-label="献立を追加"
-            onClick={() => {
-              const todayKey = formatDateKey(new Date("2026-02-09"))
-              setSelectingDate(todayKey)
-            }}
-          >
-            <Plus className="h-5 w-5" />
-          </button>
-        }
       />
 
       {/* Week Switcher */}


### PR DESCRIPTION
## 概要

- 献立カレンダー画面のヘッダー右上にある `+` ボタンを削除

## 変更理由

- ヘッダーの `+` ボタンは日付が `2026-02-09` にハードコードされており、実用上のメリットが薄いと判断（#13）
- 各日付カードの `+ レシピを追加` ボタンで同等の操作が可能

## 変更内容

- `AppHeader` の `rightElement` prop（`+` ボタン）を削除

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)