### PR TITLE
feat: 在庫管理画面に食材の追加・削除UIを実装

### DIFF
--- a/components/screens/inventory-screen.tsx
+++ b/components/screens/inventory-screen.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { Search, Filter } from "lucide-react"
+import { Search, Filter, Plus, Trash2 } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
 import { AppHeader } from "@/components/app-header"
 import {
   DropdownMenu,
@@ -11,6 +13,30 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   ingredients as initialIngredients,
   type Ingredient,
@@ -36,6 +62,10 @@ export function InventoryScreen({ onBack }: InventoryScreenProps) {
   const [items, setItems] = useState<Ingredient[]>(initialIngredients)
   const [filter, setFilter] = useState<FilterOption>("all")
   const [searchQuery, setSearchQuery] = useState("")
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [newCategory, setNewCategory] = useState<IngredientCategory>("野菜")
+  const [deleteTarget, setDeleteTarget] = useState<Ingredient | null>(null)
 
   const filteredItems = useMemo(() => {
     let filtered = items
@@ -75,6 +105,26 @@ export function InventoryScreen({ onBack }: InventoryScreenProps) {
     )
   }
 
+  const handleAddIngredient = () => {
+    if (!newName.trim()) return
+    const newItem: Ingredient = {
+      id: `custom_${Date.now()}`,
+      name: newName.trim(),
+      category: newCategory,
+      inStock: true,
+    }
+    setItems((prev) => [...prev, newItem])
+    setNewName("")
+    setNewCategory("野菜")
+    setAddDialogOpen(false)
+  }
+
+  const handleDeleteIngredient = () => {
+    if (!deleteTarget) return
+    setItems((prev) => prev.filter((item) => item.id !== deleteTarget.id))
+    setDeleteTarget(null)
+  }
+
   return (
     <div className="flex min-h-dvh flex-col bg-background">
       <AppHeader
@@ -82,36 +132,46 @@ export function InventoryScreen({ onBack }: InventoryScreenProps) {
         showBack
         onBack={onBack}
         rightElement={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  "flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg hover:bg-accent",
-                  filter !== "all" ? "text-primary" : "text-muted-foreground"
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setAddDialogOpen(true)}
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-primary hover:bg-accent"
+              aria-label="食材を追加"
+            >
+              <Plus className="h-5 w-5" />
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    "flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg hover:bg-accent",
+                    filter !== "all" ? "text-primary" : "text-muted-foreground"
+                  )}
+                  aria-label="フィルター"
+                >
+                  <Filter className="h-5 w-5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {(Object.entries(filterLabels) as [FilterOption, string][]).map(
+                  ([key, label]) => (
+                    <DropdownMenuItem
+                      key={key}
+                      onClick={() => setFilter(key)}
+                      className={cn(
+                        "text-sm",
+                        filter === key && "font-semibold text-primary"
+                      )}
+                    >
+                      {label}
+                    </DropdownMenuItem>
+                  )
                 )}
-                aria-label="フィルター"
-              >
-                <Filter className="h-5 w-5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {(Object.entries(filterLabels) as [FilterOption, string][]).map(
-                ([key, label]) => (
-                  <DropdownMenuItem
-                    key={key}
-                    onClick={() => setFilter(key)}
-                    className={cn(
-                      "text-sm",
-                      filter === key && "font-semibold text-primary"
-                    )}
-                  >
-                    {label}
-                  </DropdownMenuItem>
-                )
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         }
       />
 
@@ -172,6 +232,14 @@ export function InventoryScreen({ onBack }: InventoryScreenProps) {
                       onCheckedChange={() => toggleStock(item.id)}
                       aria-label={`${item.name}の在庫状態を切り替え`}
                     />
+                    <button
+                      type="button"
+                      onClick={() => setDeleteTarget(item)}
+                      className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground hover:text-destructive"
+                      aria-label={`${item.name}を削除`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
                   </div>
                 </div>
               ))}
@@ -179,6 +247,84 @@ export function InventoryScreen({ onBack }: InventoryScreenProps) {
           </div>
         ))}
       </main>
+
+      {/* Add Ingredient Dialog */}
+      <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+        <DialogContent className="max-w-[90vw] rounded-xl sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle className="text-foreground">食材を追加</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="newIngredientName" className="text-sm font-medium text-foreground">
+                食材名
+              </Label>
+              <Input
+                id="newIngredientName"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="例: ブロッコリー"
+                className="h-12 text-foreground"
+                onKeyDown={(e) => e.key === "Enter" && handleAddIngredient()}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label className="text-sm font-medium text-foreground">カテゴリ</Label>
+              <Select value={newCategory} onValueChange={(v) => setNewCategory(v as IngredientCategory)}>
+                <SelectTrigger className="h-12 text-foreground">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {categoryOrder.map((cat) => (
+                    <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter className="flex-row gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setAddDialogOpen(false)
+                setNewName("")
+                setNewCategory("野菜")
+              }}
+              className="h-11 flex-1 bg-transparent"
+            >
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleAddIngredient}
+              disabled={!newName.trim()}
+              className="h-11 flex-1 bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              追加
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-foreground">食材を削除しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              「{deleteTarget?.name}」を削除します。この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="h-11">キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteIngredient}
+              className="h-11 bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
closes #19

## 変更内容
- ヘッダー右上に `+` ボタンを追加（フィルターボタンの左隣）
- **食材追加ダイアログ**: 食材名入力 + カテゴリ選択（野菜/肉類/魚類/調味料/その他）、追加後は `inStock: true` でリストに反映
- **削除ボタン**: 各食材行のスイッチ右隣にゴミ箱アイコン、削除確認ダイアログ付き

## テスト項目
- [x] `+` ボタンタップ → ダイアログが開く
- [x] 食材名を入力してカテゴリを選択 → 「追加」で一覧に反映される
- [x] Enter キーで追加できる
- [x] 食材名が空の場合「追加」ボタンが無効
- [x] ゴミ箱アイコンタップ → 確認ダイアログが表示される
- [x] 「削除」確定で一覧から消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)