### PR TITLE
docs: DBスキーマ設計・DB選定ドキュメントを追加 (#21)

### DIFF
--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -1,0 +1,208 @@
+# DBスキーマ設計
+
+## ユーザー関連テーブル
+
+```mermaid
+erDiagram
+  users {
+    uuid id PK
+    string google_id UK "Googleアカウント識別子"
+    string email UK
+    string name
+    timestamp created_at
+    timestamp deleted_at "NULL: 有効"
+  }
+
+  households {
+    uuid id PK
+    string name "家庭名"
+    timestamp created_at
+    timestamp deleted_at "NULL: 有効"
+  }
+
+  household_members {
+    uuid id PK
+    uuid user_id FK
+    uuid household_id FK
+    string role "owner | member"
+    timestamp joined_at
+    timestamp deleted_at "NULL: 在籍中"
+  }
+
+  users ||--o{ household_members : "所属する"
+  households ||--o{ household_members : "構成される"
+```
+
+### 補足
+
+**users**
+- `google_id`: Google OAuth で取得する `sub` クレーム。ログイン時の照合に使用。
+- `email`: Google アカウントのメールアドレス。
+
+**households**
+- 1ユーザーが複数の家庭に所属することを想定した設計（例: 実家と自分の家）。
+- MVP では1ユーザー1家庭を前提として扱う。
+
+**household_members**
+- `role`: `owner`（家庭を作成したユーザー）/ `member`（招待されたユーザー）。
+- MVP では role による権限制御は実装しないが、将来の拡張のためカラムを持つ。
+
+---
+
+## 食材・在庫関連テーブル
+
+```mermaid
+erDiagram
+  ingredients {
+    uuid id PK
+    string name "食材名"
+    string category "野菜 | 肉類 | 魚類 | 調味料 | その他"
+    timestamp created_at
+  }
+
+  inventory {
+    uuid id PK
+    uuid household_id FK
+    uuid ingredient_id FK
+    boolean in_stock "在庫あり: true"
+    timestamp updated_at
+  }
+
+  households ||--o{ inventory : "管理する"
+  ingredients ||--o{ inventory : "記録される"
+```
+
+### 補足
+
+**ingredients**
+- 食材のマスタテーブル。全家庭で共有する。
+- MVP では固定のマスタデータをシードとして投入する。
+- MVP 以降、分量単位（例: g、個）を管理するカラムの追加を予定している。
+-  MVP 以降、カテゴリー分類の拡張（果物、お菓子など）を予定している。
+
+**inventory**
+- 家庭ごとの在庫状態を管理する。`ingredients` とは分離することで、同じ食材でも家庭によって在庫状況が異なる状態を表現できる。
+- `in_stock` のデフォルトは `false`（在庫なし）。
+- `(household_id, ingredient_id)` に UNIQUE 制約を付ける（1家庭につき1食材1レコード）。
+
+---
+
+## レシピ関連テーブル
+
+```mermaid
+erDiagram
+  recipes {
+    uuid id PK
+    uuid household_id FK
+    string name "レシピ名"
+    string url "参考レシピURL（任意）"
+    timestamp created_at
+    timestamp deleted_at "NULL: 有効"
+  }
+
+  recipe_ingredients {
+    uuid id PK
+    uuid recipe_id FK
+    uuid ingredient_id FK
+  }
+
+  households ||--o{ recipes : "所有する"
+  recipes ||--o{ recipe_ingredients : "構成される"
+  ingredients ||--o{ recipe_ingredients : "使われる"
+```
+
+### 補足
+
+**recipes**
+- 家庭ごとのレシピを管理する（`household_id` で紐づけ）。他の家庭のレシピは参照できない。
+- `url` は任意項目。外部レシピサイトへのリンクを保存する。
+
+**recipe_ingredients**
+- レシピと食材の中間テーブル。
+- `(recipe_id, ingredient_id)` に UNIQUE 制約を付ける（同じ食材の重複登録を防ぐ）。
+- MVP 以降、分量単位カラムの追加を予定している（ingredients テーブルの分量単位対応と連動）。
+
+---
+
+## 献立関連テーブル
+
+```mermaid
+erDiagram
+  meal_plans {
+    uuid id PK
+    uuid household_id FK
+    uuid recipe_id FK "NULL許容（未設定日）"
+    date date "献立日"
+    timestamp created_at
+    timestamp updated_at
+    timestamp deleted_at "NULL: 有効"
+  }
+
+  households ||--o{ meal_plans : "計画する"
+  recipes ||--o{ meal_plans : "割り当てられる"
+```
+
+### 補足
+
+**meal_plans**
+- 家庭ごとの日付別献立を管理する。
+- `recipe_id` は NULL 許容。献立未設定の日もレコードとして持つことができるが、MVP ではレシピが設定された日のみ INSERT する運用を想定。
+- `(household_id, date)` に UNIQUE 制約を付ける（1家庭1日1献立）。
+
+---
+
+## ログ・分析関連テーブル
+
+```mermaid
+erDiagram
+  activity_logs {
+    uuid id PK
+    uuid household_id FK
+    uuid user_id FK
+    string event_type "イベント種別"
+    jsonb payload "イベント固有データ"
+    timestamp created_at
+  }
+
+  households ||--o{ activity_logs : "記録される"
+  users ||--o{ activity_logs : "起こす"
+```
+
+### 補足
+
+**activity_logs**
+- ユーザーの行動イベントを記録する。データ分析・消費傾向の把握を目的とする。
+- `event_type` の例:
+  - `ingredient_consumed`: 食材を使い切った
+  - `recipe_cooked`: 献立を完了した
+  - `inventory_updated`: 在庫状態を変更した
+- `payload` は JSONB 型。イベントごとの追加データ（どの食材か、どのレシピかなど）を柔軟に格納する。
+- MVP では記録のみ行い、分析 UI の実装は MVP 以降とする。
+
+### データ分析の将来構成
+
+データ量が増えた段階では、OLTP と OLAP を分離する構成を想定する。
+
+```
+Supabase (OLTP) → ETL / Logical Replication → BigQuery (OLAP)
+```
+
+Supabase は PostgreSQL の論理レプリケーションおよび Webhook 経由での BigQuery 連携が可能なため、将来のデータ基盤への移行パスが確保されている。
+
+### ソフトデリートの方針
+
+分析時に削除済みデータを参照できるよう、以下のテーブルに `deleted_at` カラムを持つ。`NULL` の場合は有効なレコード、値がある場合は削除済みとして扱う。
+
+| テーブル | 追加 | 目的 |
+|----------|------|------|
+| `users` | ✅ | アカウント削除後も `activity_logs` との紐づけを保持 |
+| `households` | ✅ | 家庭解散後の履歴追跡 |
+| `household_members` | ✅ | 脱退メンバーの行動履歴を保持 |
+| `recipes` | ✅ | 削除済みレシピの調理回数などを分析 |
+| `meal_plans` | ✅ | 削除された献立の履歴を分析 |
+| `ingredients` | ❌ | グローバルマスタのため削除は基本発生しない |
+| `inventory` | ❌ | 在庫状態の管理テーブルであり履歴不要 |
+| `recipe_ingredients` | ❌ | `recipes` の削除に追従するため個別管理不要 |
+| `activity_logs` | ❌ | ログは削除しない |
+
+アプリ側では通常クエリに `WHERE deleted_at IS NULL` を付与し、削除済みレコードを除外して扱う。

--- a/docs/DB_SELECTION.md
+++ b/docs/DB_SELECTION.md
@@ -1,0 +1,44 @@
+# DB選定
+
+## 評価軸
+
+| # | 軸 | 説明 |
+|---|----|----|
+| ① | 機能要件との適合 | Google OAuth 連携・リアルタイム同期対応 |
+| ② | 運用・スケール | 想定ユーザー数への対応・マルチテナント設計 |
+| ③ | 開発体験 | Next.js / TypeScript 親和性・マイグレーション・ローカル開発 |
+| ④ | コスト | 無料枠・スケール時の料金 |
+| ⑤ | セキュリティ・RLS | household 単位のデータアクセス制御 |
+
+---
+
+## 候補比較
+
+| 評価軸 | Supabase | Firebase Firestore | Neon | PlanetScale | Cloud SQL (GCP) | Aurora Serverless v2 (AWS) |
+|--------|----------|--------------------|------|-------------|-----------------|----------------------------|
+| **① 機能要件** | Google OAuth を Auth モジュールで標準対応。Realtime サブスクリプションあり | Google 製品のため Google Auth と完全統合。Realtime がネイティブ | Auth・Realtime は非搭載。別途実装が必要 | Auth・Realtime は非搭載。別途実装が必要 | Auth は非搭載。GCP の Identity Platform と組み合わせれば Google Auth 対応可。Realtime は非搭載 | Auth は非搭載。Cognito と組み合わせれば Google Auth 対応可。Realtime は非搭載 |
+| **② 運用・スケール** | PostgreSQL ベース。RLS で household 単位のマルチテナントを DB 層で実現 | NoSQL のためスキーマレスで柔軟。Security Rules でテナント分離。スキーマ変更に強い | サーバーレス PostgreSQL。ブランチ機能でステージング環境管理が容易 | MySQL 互換。大規模スケールに強いが MVP 規模では過剰 | フルマネージド PostgreSQL / MySQL。GCP エコシステムとの親和性が高く、大規模運用に実績あり | PostgreSQL 互換のサーバーレス DB。トラフィックに応じて自動スケール。0 スケールも可能 |
+| **③ 開発体験** | Next.js 向け SDK あり。CLI でローカル開発環境を構築可能。マイグレーションは SQL または Prisma で管理 | TypeScript SDK あり。NoSQL のためリレーショナルな設計と思想が異なりスキーマ管理が難しい | Vercel / Next.js との統合が優秀。標準 SQL + Prisma が使える | 2024年に無料プラン廃止。DX は良好だがコスト面で選択しにくい | 標準 SQL + Prisma 対応。ただし GCP コンソールの設定が煩雑で初期セットアップのコストが高い | 標準 SQL + Prisma 対応。AWS コンソール・IAM の設定が複雑で、小規模 MVP には過剰な学習コストがかかる |
+| **④ コスト** | 無料枠: DB 500MB・2プロジェクト。非アクティブ時は1週間でポーズ | 無料枠: Spark プランで Firestore 1GB・Cloud Functions 一部利用可 | 無料枠: DB 0.5GB・コンピュートはポーズあり | **無料プランなし**（最低 $39/月〜） | **無料枠なし**。新規 GCP アカウントは $300 クレジットあり。最低でも数ドル/月〜 | **無料枠なし**。最低 $0.12/ACU-hour 〜。停止中も最小コストが発生する場合あり |
+| **⑤ セキュリティ・RLS** | RLS がコア機能として組み込まれており、SQL ポリシーで household 単位のアクセス制御を DB 層で保証できる | Security Rules で制御可能だが、リレーショナルデータへの適用はアプリ層での補完が必要になる場面がある | PostgreSQL のため RLS を SQL で実装可能だが、管理 UI はなく手動運用 | RLS 非対応。アプリケーション層での制御に依存 | PostgreSQL のため RLS を SQL で実装可能。IAM との連携によるアクセス制御も可能だが設定が複雑 | PostgreSQL 互換のため RLS を SQL で実装可能。IAM・VPC 等との組み合わせで高度なセキュリティ構成が可能だが設定コストが高い |
+
+---
+
+## 結論
+
+**Supabase を採用する。**
+
+このアプリの要件（Google OAuth・household 単位の RLS・リアルタイム同期・Next.js）をほぼノーコストで満たせる唯一の選択肢。MVP 段階の無料枠内で開発・リリースまで対応できる。
+
+### 採用の根拠
+
+- Google OAuth が Auth モジュールで即利用可能
+- RLS が標準機能として備わっており、household 単位のデータ分離を DB 層で保証できる
+- Next.js 向け SDK と CLI によるローカル開発環境が整備されており、開発体験が良好
+- 無料枠で MVP リリースまで賄える
+- PostgreSQL の論理レプリケーションおよび Webhook 経由で BigQuery 等のデータウェアハウスへの ETL が可能なため、将来のデータ分析基盤への移行パスが確保されている
+
+### 留意点
+
+- 無料プロジェクトは **7日間非アクティブでポーズ**される（本番運用時は有料プランへの移行を検討）
+- Realtime はオプション機能として利用可能だが、MVP では必須ではない


### PR DESCRIPTION
## Summary

- `docs/DB_SCHEMA.md` を新規作成: 全8テーブルのER図をMermaid形式で記述
  - ユーザー関連: `users`, `households`, `household_members`
  - 食材・在庫関連: `ingredients`, `inventory`
  - レシピ関連: `recipes`, `recipe_ingredients`
  - 献立関連: `meal_plans`
  - ログ・分析関連: `activity_logs`（将来のデータ分析用）
  - ソフトデリート（`deleted_at`）を主要5テーブルに適用
  - 将来のOLTP→OLAP（BigQuery等）分離構成を記載
- `docs/DB_SELECTION.md` を新規作成: 6候補を5軸で比較しSupabaseを採用決定
  - 比較候補: Supabase / Firebase Firestore / Neon / PlanetScale / Cloud SQL (GCP) / Aurora Serverless v2 (AWS)
  - 評価軸: 機能要件・運用スケール・開発体験・コスト・RLS

## Test plan

- [x] GitHub上でMermaidのER図が正しくレンダリングされることを確認
- [x] DB_SELECTION.mdの比較表が正しく表示されることを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)