### PR TITLE
feat: 型定義の分離

### DIFF
--- a/components/screens/inventory-screen.tsx
+++ b/components/screens/inventory-screen.tsx
@@ -37,11 +37,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import {
-  ingredients as initialIngredients,
-  type Ingredient,
-  type IngredientCategory,
-} from "@/lib/mock-data"
+import { ingredients as initialIngredients } from "@/lib/mock-data"
+import type { Ingredient, IngredientCategory } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
 type FilterOption = "all" | "in-stock" | "out-of-stock"

--- a/components/screens/meal-plan-screen.tsx
+++ b/components/screens/meal-plan-screen.tsx
@@ -19,8 +19,8 @@ import {
   getRecipeById,
   getIngredientById,
   dayNames,
-  type MealPlan,
 } from "@/lib/mock-data"
+import type { MealPlan } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
 interface MealPlanScreenProps {

--- a/components/screens/recipe-screen.tsx
+++ b/components/screens/recipe-screen.tsx
@@ -27,13 +27,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
-import {
-  recipes as initialRecipes,
-  ingredients as masterIngredients,
-  type Recipe,
-  type Ingredient,
-  type IngredientCategory,
-} from "@/lib/mock-data"
+import { recipes as initialRecipes, ingredients as masterIngredients } from "@/lib/mock-data"
+import type { Recipe, Ingredient, IngredientCategory } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
 type RecipeView = "list" | "detail" | "edit"

--- a/components/screens/settings-screen.tsx
+++ b/components/screens/settings-screen.tsx
@@ -23,7 +23,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { householdMembers, type HouseholdMember } from "@/lib/mock-data"
+import { householdMembers } from "@/lib/mock-data"
+import type { HouseholdMember } from "@/lib/types"
 
 interface SettingsScreenProps {
   onBack: () => void

--- a/components/screens/shopping-list-screen.tsx
+++ b/components/screens/shopping-list-screen.tsx
@@ -15,7 +15,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
-import { getShoppingList, type ShoppingItem, type IngredientCategory } from "@/lib/mock-data"
+import { getShoppingList } from "@/lib/mock-data"
+import type { ShoppingItem, IngredientCategory } from "@/lib/types"
 
 interface ShoppingListScreenProps {
   onBack: () => void

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,40 +1,12 @@
 // Mock data for the food management app prototype
 
-export type IngredientCategory = "野菜" | "肉類" | "魚類" | "調味料" | "その他"
-
-export interface Ingredient {
-  id: string
-  name: string
-  category: IngredientCategory
-  inStock: boolean
-}
-
-export interface Recipe {
-  id: string
-  name: string
-  ingredients: string[] // ingredient IDs
-  url?: string
-}
-
-export interface MealPlan {
-  date: string // YYYY-MM-DD
-  recipeId: string | null
-}
-
-export interface ShoppingItem {
-  ingredientId: string
-  ingredientName: string
-  category: IngredientCategory
-  reason: string
-  checked: boolean
-}
-
-export interface HouseholdMember {
-  id: string
-  name: string
-  email: string
-  isCurrentUser: boolean
-}
+import type {
+  Ingredient,
+  Recipe,
+  MealPlan,
+  ShoppingItem,
+  HouseholdMember,
+} from "@/lib/types"
 
 // ---- Ingredients Master ----
 export const ingredients: Ingredient[] = [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,35 @@
+export type IngredientCategory = "野菜" | "肉類" | "魚類" | "調味料" | "その他"
+
+export interface Ingredient {
+  id: string
+  name: string
+  category: IngredientCategory
+  inStock: boolean
+}
+
+export interface Recipe {
+  id: string
+  name: string
+  ingredients: string[] // ingredient IDs
+  url?: string
+}
+
+export interface MealPlan {
+  date: string // YYYY-MM-DD
+  recipeId: string | null
+}
+
+export interface ShoppingItem {
+  ingredientId: string
+  ingredientName: string
+  category: IngredientCategory
+  reason: string
+  checked: boolean
+}
+
+export interface HouseholdMember {
+  id: string
+  name: string
+  email: string
+  isCurrentUser: boolean
+}


### PR DESCRIPTION
## Summary
- `lib/types.ts` を新設し、型定義を `mock-data.ts` から分離
- `mock-data.ts` はデータとヘルパー関数のみに（型は `lib/types` からimport）
- 6スクリーンの型importを `@/lib/mock-data` から `@/lib/types` に変更
  - `meal-plan-screen.tsx` — `MealPlan`
  - `inventory-screen.tsx` — `Ingredient`, `IngredientCategory`
  - `recipe-screen.tsx` — `Recipe`, `Ingredient`, `IngredientCategory`
  - `shopping-list-screen.tsx` — `ShoppingItem`, `IngredientCategory`
  - `settings-screen.tsx` — `HouseholdMember`

Closes #59

## Test plan
- [x] `npx tsc --noEmit` がエラーなしで通る
- [x] 各画面が正常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)