### PR TITLE
fix: 買い物リスト完了ボタンの見切れを修正

### DIFF
--- a/components/screens/shopping-list-screen.tsx
+++ b/components/screens/shopping-list-screen.tsx
@@ -103,7 +103,7 @@ export function ShoppingListScreen({ onBack }: ShoppingListScreenProps) {
       </div>
 
       {/* Shopping List */}
-      <main className="flex-1 overflow-y-auto pb-24">
+      <main className="flex-1 overflow-y-auto pb-36">
         {groupedItems.map((group) => (
           <div key={group.category}>
             <div className="sticky top-0 z-10 bg-background px-4 py-2">
@@ -145,7 +145,7 @@ export function ShoppingListScreen({ onBack }: ShoppingListScreenProps) {
       </main>
 
       {/* Fixed Footer Button */}
-      <div className="fixed bottom-0 left-0 right-0 border-t border-border bg-card p-4">
+      <div className="fixed bottom-16 left-0 right-0 border-t border-border bg-card p-4">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button


### PR DESCRIPTION
## Summary
- 完了ボタンが `fixed bottom-0` のままだとBottomNav（64px）の裏に隠れていたため `bottom-16` に変更
- スクロール領域の下部余白を `pb-24` → `pb-36` に拡大し、リスト末尾がボタンに隠れないよう調整

## Test plan
- [x] 買い物リスト画面を開き、完了ボタンがBottomNavの上に表示される
- [x] リストをスクロールしても最下部の項目が完了ボタンに隠れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)