### PR TITLE
feat: カテゴリ定義をlib/constants.tsに集約

### DIFF
--- a/components/screens/inventory-screen.tsx
+++ b/components/screens/inventory-screen.tsx
@@ -40,14 +40,13 @@ import {
 import { getIngredients } from "@/lib/api/ingredients"
 import type { Ingredient, IngredientCategory } from "@/lib/types"
 import { cn } from "@/lib/utils"
+import { categoryOrder } from "@/lib/constants"
 
 type FilterOption = "all" | "in-stock" | "out-of-stock"
 
 interface InventoryScreenProps {
   onBack: () => void
 }
-
-const categoryOrder: IngredientCategory[] = ["野菜", "肉類", "魚類", "調味料", "その他"]
 
 const filterLabels: Record<FilterOption, string> = {
   all: "すべて",

--- a/components/screens/shopping-list-screen.tsx
+++ b/components/screens/shopping-list-screen.tsx
@@ -17,12 +17,11 @@ import {
 } from "@/components/ui/alert-dialog"
 import { getShoppingList } from "@/lib/api/shopping"
 import type { ShoppingItem, IngredientCategory } from "@/lib/types"
+import { categoryOrder } from "@/lib/constants"
 
 interface ShoppingListScreenProps {
   onBack: () => void
 }
-
-const categoryOrder: IngredientCategory[] = ["野菜", "肉類", "魚類", "調味料", "その他"]
 
 export function ShoppingListScreen({ onBack }: ShoppingListScreenProps) {
   const [items, setItems] = useState<ShoppingItem[]>(() => getShoppingList())

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,3 @@
+import type { IngredientCategory } from "@/lib/types"
+
+export const categoryOrder: IngredientCategory[] = ["野菜", "肉類", "魚類", "調味料", "その他"]


### PR DESCRIPTION
## Summary
- `shopping-list-screen.tsx` と `inventory-screen.tsx` に重複定義されていた `categoryOrder` を `lib/constants.ts` に集約
- 各画面は `@/lib/constants` からimportするよう変更

Closes #62

## Test plan
- [x] 買い物リスト画面のカテゴリ別グルーピングが正常に表示される
- [x] 在庫画面のカテゴリ別グルーピングが正常に表示される
- [x] TypeScript型チェック通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)