### PR TITLE
feat: レシピ管理API実装・フロント接続 (#25)

### DIFF
--- a/app/api/ingredients/route.ts
+++ b/app/api/ingredients/route.ts
@@ -1,0 +1,50 @@
+import { createClient } from "@/lib/supabase/server"
+import { createClient as createServiceClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+
+// GET /api/ingredients - 全食材一覧（グローバルマスタ＋家庭専用）と在庫状態
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data: member } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("user_id", user.id)
+    .is("deleted_at", null)
+    .single()
+
+  if (!member) return NextResponse.json({ error: "No household" }, { status: 404 })
+
+  const admin = createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const [ingredientsRes, inventoryRes] = await Promise.all([
+    admin
+      .from("ingredients")
+      .select("id, name, category")
+      .or(`household_id.is.null,household_id.eq.${member.household_id}`)
+      .order("name"),
+    supabase.from("inventory").select("ingredient_id, in_stock"),
+  ])
+
+  if (ingredientsRes.error) {
+    return NextResponse.json({ error: ingredientsRes.error.message }, { status: 400 })
+  }
+
+  const inventoryMap = new Map(
+    (inventoryRes.data ?? []).map((i) => [i.ingredient_id, i.in_stock])
+  )
+
+  const result = (ingredientsRes.data ?? []).map((ing) => ({
+    id: ing.id,
+    name: ing.name,
+    category: ing.category,
+    inStock: inventoryMap.get(ing.id) ?? false,
+  }))
+
+  return NextResponse.json(result)
+}

--- a/app/api/recipes/[id]/route.ts
+++ b/app/api/recipes/[id]/route.ts
@@ -1,0 +1,67 @@
+import { createClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+
+// PATCH /api/recipes/[id] - レシピ更新（名前・URL・食材を全置換）
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { id } = await params
+  const { name, url, ingredients } = await request.json()
+
+  if (!name?.trim()) return NextResponse.json({ error: "name is required" }, { status: 400 })
+
+  const { data: recipe, error } = await supabase
+    .from("recipes")
+    .update({ name: name.trim(), url: url?.trim() || null })
+    .eq("id", id)
+    .is("deleted_at", null)
+    .select("id, name, url")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+
+  // recipe_ingredients を全削除→再INSERT
+  await supabase.from("recipe_ingredients").delete().eq("recipe_id", id)
+
+  const ingredientIds: string[] = ingredients ?? []
+  if (ingredientIds.length > 0) {
+    const { error: riError } = await supabase
+      .from("recipe_ingredients")
+      .insert(ingredientIds.map((ingId) => ({ recipe_id: id, ingredient_id: ingId })))
+    if (riError) return NextResponse.json({ error: riError.message }, { status: 400 })
+  }
+
+  return NextResponse.json({
+    id: recipe.id,
+    name: recipe.name,
+    url: recipe.url ?? undefined,
+    ingredients: ingredientIds,
+  })
+}
+
+// DELETE /api/recipes/[id] - ソフトデリート（deleted_at をセット）
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { id } = await params
+
+  const { error } = await supabase
+    .from("recipes")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .is("deleted_at", null)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/recipes/route.ts
+++ b/app/api/recipes/route.ts
@@ -1,0 +1,70 @@
+import { createClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+
+// GET /api/recipes - レシピ一覧（削除済み除く）
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from("recipes")
+    .select("id, name, url, recipe_ingredients(ingredient_id)")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+
+  const recipes = (data ?? []).map((r) => ({
+    id: r.id,
+    name: r.name,
+    url: r.url ?? undefined,
+    ingredients: (r.recipe_ingredients as { ingredient_id: string }[]).map(
+      (ri) => ri.ingredient_id
+    ),
+  }))
+
+  return NextResponse.json(recipes)
+}
+
+// POST /api/recipes - レシピ作成
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { name, url, ingredients } = await request.json()
+  if (!name?.trim()) return NextResponse.json({ error: "name is required" }, { status: 400 })
+
+  const { data: member } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("user_id", user.id)
+    .is("deleted_at", null)
+    .single()
+
+  if (!member) return NextResponse.json({ error: "No household" }, { status: 404 })
+
+  const { data: recipe, error } = await supabase
+    .from("recipes")
+    .insert({ name: name.trim(), url: url?.trim() || null, household_id: member.household_id })
+    .select("id, name, url")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+
+  const ingredientIds: string[] = ingredients ?? []
+  if (ingredientIds.length > 0) {
+    const { error: riError } = await supabase
+      .from("recipe_ingredients")
+      .insert(ingredientIds.map((id) => ({ recipe_id: recipe.id, ingredient_id: id })))
+    if (riError) return NextResponse.json({ error: riError.message }, { status: 400 })
+  }
+
+  return NextResponse.json({
+    id: recipe.id,
+    name: recipe.name,
+    url: recipe.url ?? undefined,
+    ingredients: ingredientIds,
+  })
+}

--- a/components/screens/recipe-screen.tsx
+++ b/components/screens/recipe-screen.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { useState } from "react"
-import { getRecipes } from "@/lib/api/recipes"
-import { getIngredients } from "@/lib/api/ingredients"
+import { useState, useEffect } from "react"
 import type { Recipe, Ingredient } from "@/lib/types"
 import { RecipeListView } from "@/components/screens/recipe-list-view"
 import { RecipeDetailView } from "@/components/screens/recipe-detail-view"
@@ -15,13 +13,22 @@ interface RecipeScreenProps {
 }
 
 export function RecipeScreen({ onBack }: RecipeScreenProps) {
-  const [recipeList, setRecipeList] = useState<Recipe[]>(getRecipes)
-  const [customIngredients, setCustomIngredients] = useState<Ingredient[]>([])
+  const [recipeList, setRecipeList] = useState<Recipe[]>([])
+  const [allIngredients, setAllIngredients] = useState<Ingredient[]>([])
   const [view, setView] = useState<RecipeView>("list")
   const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null)
   const [isNewRecipe, setIsNewRecipe] = useState(false)
 
-  const allIngredients = [...getIngredients(), ...customIngredients]
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/recipes").then((r) => r.json()),
+      fetch("/api/ingredients").then((r) => r.json()),
+    ]).then(([recipes, ingredients]) => {
+      if (Array.isArray(recipes)) setRecipeList(recipes)
+      if (Array.isArray(ingredients)) setAllIngredients(ingredients)
+    })
+  }, [])
+
   const selectedRecipe = recipeList.find((r) => r.id === selectedRecipeId)
 
   const handleOpenDetail = (recipeId: string) => {
@@ -34,7 +41,7 @@ export function RecipeScreen({ onBack }: RecipeScreenProps) {
     setView("edit")
   }
 
-  const handleSaveRecipe = ({
+  const handleSaveRecipe = async ({
     name,
     url,
     ingredients,
@@ -45,36 +52,67 @@ export function RecipeScreen({ onBack }: RecipeScreenProps) {
     ingredients: string[]
     newCustomIngredients: Ingredient[]
   }) => {
-    if (newCustomIngredients.length > 0) {
-      setCustomIngredients((prev) => [...prev, ...newCustomIngredients])
+    // 新規食材をAPIで作成して一時IDと本物のIDをマッピング
+    const idMap = new Map<string, string>()
+    for (const ing of newCustomIngredients) {
+      const res = await fetch("/api/inventory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: ing.name, category: ing.category }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        const realIngredientId = (data.ingredients as { id: string } | null)?.id
+        if (realIngredientId) idMap.set(ing.id, realIngredientId)
+      }
     }
 
+    // 一時IDを本物のIDに置換
+    const resolvedIngredients = ingredients.map((id) => idMap.get(id) ?? id)
+
     if (isNewRecipe) {
-      const newRecipe: Recipe = {
-        id: `r${Date.now()}`,
-        name,
-        ingredients,
-        ...(url && { url }),
+      const res = await fetch("/api/recipes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, url, ingredients: resolvedIngredients }),
+      })
+      if (res.ok) {
+        const newRecipe: Recipe = await res.json()
+        setRecipeList((prev) => [newRecipe, ...prev])
+        setSelectedRecipeId(newRecipe.id)
       }
-      setRecipeList((prev) => [...prev, newRecipe])
-      setSelectedRecipeId(newRecipe.id)
     } else if (selectedRecipeId) {
-      setRecipeList((prev) =>
-        prev.map((r) =>
-          r.id === selectedRecipeId
-            ? { ...r, name, ingredients, url: url || undefined }
-            : r
+      const res = await fetch(`/api/recipes/${selectedRecipeId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, url, ingredients: resolvedIngredients }),
+      })
+      if (res.ok) {
+        const updated: Recipe = await res.json()
+        setRecipeList((prev) =>
+          prev.map((r) => (r.id === selectedRecipeId ? updated : r))
         )
-      )
+      }
     }
+
+    // 新規食材があった場合は ingredients 一覧を再取得
+    if (newCustomIngredients.length > 0) {
+      fetch("/api/ingredients")
+        .then((r) => r.json())
+        .then((data) => { if (Array.isArray(data)) setAllIngredients(data) })
+    }
+
     setView("detail")
   }
 
-  const handleDeleteRecipe = () => {
+  const handleDeleteRecipe = async () => {
     if (!selectedRecipeId) return
-    setRecipeList((prev) => prev.filter((r) => r.id !== selectedRecipeId))
-    setSelectedRecipeId(null)
-    setView("list")
+    const res = await fetch(`/api/recipes/${selectedRecipeId}`, { method: "DELETE" })
+    if (res.ok) {
+      setRecipeList((prev) => prev.filter((r) => r.id !== selectedRecipeId))
+      setSelectedRecipeId(null)
+      setView("list")
+    }
   }
 
   if (view === "list") {

--- a/docs/adr/0010-recipe-management.md
+++ b/docs/adr/0010-recipe-management.md
@@ -1,0 +1,65 @@
+# ADR-0010: レシピ管理の設計方針
+
+## Status
+
+Accepted
+
+## Context
+
+レシピ管理APIの実装にあたり、以下の設計を決定する必要があった。
+
+- レシピ削除の方式（物理削除 vs ソフトデリート）
+- レシピ編集時の食材選択ソース（`inventory` vs `ingredients`）
+- `recipe_ingredients` の更新方式
+
+## Decision Drivers
+
+- 過去の献立データ（`meal_plans`）が壊れないこと
+- レシピ編集時の食材選択が直感的であること
+- 実装がシンプルで保守しやすいこと
+
+## Considered Options
+
+**レシピ削除の方式：**
+- A. 物理削除（`DELETE FROM recipes`）
+- **B. ソフトデリート（`deleted_at` をセット）（採用）**
+
+**食材選択ソース：**
+- A. `inventory`（家庭が在庫管理している食材のみ）
+- **B. `ingredients`（グローバルマスタ＋家庭専用食材の全件）（採用）**
+
+**`recipe_ingredients` の更新方式：**
+- A. 差分更新（追加分INSERTと削除分DELETEを個別に計算）
+- **B. 全削除→再INSERT（採用）**
+
+## Decision
+
+### レシピ削除：ソフトデリート
+
+`meal_plans.recipe_id` が `recipes.id` を参照しているため、物理削除すると過去の献立データが壊れる。
+`deleted_at` に日時をセットするソフトデリートを採用し、レシピ一覧取得時は `deleted_at IS NULL` で絞り込む。
+
+### 食材選択ソース：`ingredients` テーブル
+
+レシピに「使う食材」を登録する際、在庫の有無は関係ない。
+むしろ「在庫にない食材を使うレシピ」を登録することで、買い物リスト生成（Issue #27）の入力として機能する。
+
+`inventory` を使うと「在庫に追加していない食材はレシピに入れられない」という制約が生まれ、ユーザー体験を損なう。
+
+`GET /api/ingredients` は `ingredients` テーブルから全件取得し、`inventory` とのLEFT JOINで在庫状態（`inStock`）を付加して返す。これによりレシピ詳細画面で各食材の在庫状態も表示できる。
+
+### `recipe_ingredients` の更新：全削除→再INSERT
+
+差分更新は実装が複雑で、バグが入り込みやすい。`recipe_ingredients` は軽量なレコード（recipe_id + ingredient_id のみ）のため、全削除→再INSERTのコストは無視できる。
+
+## Consequences
+
+**Positive:**
+- 過去の献立データが削除されたレシピを参照しても整合性が保たれる
+- レシピ編集時に在庫に関係なく任意の食材を選択できる
+- `recipe_ingredients` の更新ロジックがシンプル
+
+**Negative:**
+- ソフトデリートのため `recipes` テーブルにデータが残り続ける（将来的に物理削除のバッチが必要になる可能性）
+- `GET /api/ingredients` は admin クライアントを使用（Issue #82 の対象）
+- 現在の食材コピペ解析（`recipe-parser.ts`）は文字列一致のみで表記揺れ（ひらがな・カタカナ等）に対応していない。Issue #73（Claude API連携）で意味的な解析・マスタ照合に置き換える予定

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@
 | [0007](0007-authentication.md) | 認証方式の選定 | Accepted | Supabase Auth + Google OAuthを採用。NextAuth.js不要で、RLSと認証を一体化できる |
 | [0008](0008-household-management.md) | 家庭管理の設計方針 | Accepted | MVP：初回ログイン時に家庭を自動作成、メールアドレスでメンバー追加。将来的に招待リンク方式へ拡張予定 |
 | [0009](0009-inventory-design.md) | 在庫管理の設計方針 | Accepted | 在庫画面はinventoryテーブルのみ参照。家庭作成時にDBトリガーでグローバルマスタ全件をinventoryに初期化 |
+| [0010](0010-recipe-management.md) | レシピ管理の設計方針 | Accepted | ソフトデリート採用（meal_plans参照保護）。食材選択はinventoryでなくingredientsから（在庫無関係に選択可）|


### PR DESCRIPTION
## Summary

- `GET /api/ingredients`：全食材（グローバルマスタ＋家庭専用）を在庫状態付きで返却
- `GET /api/recipes`：ソフトデリート済みを除くレシピ一覧を recipe_ingredients 込みで返却
- `POST /api/recipes`：レシピ作成
- `PATCH /api/recipes/[id]`：名前・URL・食材を更新（recipe_ingredients は全削除→再INSERT）
- `DELETE /api/recipes/[id]`：ソフトデリート（`deleted_at` をセット）
- `recipe-screen.tsx` をモックから実APIに接続
- ADR-0010 追加：ソフトデリート採用理由・食材選択ソースの設計判断を記録

## Test plan

- [x] レシピ一覧が表示される（DB に既存レシピがなければ空）
- [x] 「＋」でレシピ作成 → 食材選択ダイアログに全食材が表示される
- [x] 保存するとリストに追加される
- [x] 詳細画面で食材ごとの在庫状態が表示される
- [x] 編集→保存で更新される
- [x] 削除（ソフトデリート）で一覧から消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)